### PR TITLE
Put gem stub binary into a versioned folder

### DIFF
--- a/lib/exefy.rb
+++ b/lib/exefy.rb
@@ -2,6 +2,7 @@ module Exefy
   require 'rubygems'
   require 'rubygems/user_interaction'
   require 'tmpdir'
+  require 'rbconfig'
 
   def self.process_existing_gem(gem, revert)
     generator = GeneratorFromBatch.new(gem)
@@ -40,8 +41,10 @@ module Exefy
     def executable
       return @executable if defined?(@executable)
 
-      gem_root = File.expand_path("../..", __FILE__)
-      @executable = File.join(gem_root, "data", "gemstub.exe")
+      gem_root     = File.expand_path("../..", __FILE__)
+      ruby_version = RbConfig::CONFIG["ruby_version"]
+
+      @executable = File.join(gem_root, "data", ruby_version, "gemstub.exe")
     end
 
     def generate_executable


### PR DESCRIPTION
This modification is required to avoid 'clash' of same gem installed and
used across different versions of Ruby's API (1.8 vs 1.9.1)

This clash happens for users using combinations of either GEM_HOME and/or
GEM_PATH environment variables that affect normal RubyGems directory
resolution.
