### PR TITLE
Solve no return warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .bundle
 .config
 coverage
+data
 InstalledFiles
 lib/bundler/man
 pkg

--- a/templates/gem_exe.c
+++ b/templates/gem_exe.c
@@ -81,4 +81,7 @@ main(int argc, char **argv)
       printf("Not enough memory to continue. Exiting...");
     }
   }
+
+  // Return an error when nothing works
+  return -1;
 }


### PR DESCRIPTION
Solve control reach end of non-void function

Non-explicit return from a non-void function causes warnings with the GCC flags used by Ruby 2.0.0 (trunk):

```
C:\>gem exefy --all
Temporarily enhancing PATH to include DevKit...
C:/.../2.0.0/gems/gem-exefy-1.0.0-x86-mingw32/templates/gem_exe.c: In function 'main':
C:/.../2.0.0/gems/gem-exefy-1.0.0-x86-mingw32/templates/gem_exe.c:84:1: warning: control reaches end of non-void function
```

The change included suppress such warning.

I've also ignored `data` directory to avoid possible commits of it :tongue:

Thanks! :heart: :heart: :heart:
