### PR TITLE
Enforce minimum version of Ruby to 1.9.3

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,6 +15,7 @@ Hoe.spec 'gem-exefy' do
   self.require_rubygems_version(">= 1.8.0")
   self.version = Exefy::VERSION
   spec_extras[:platform] = Gem::Platform::CURRENT
+  spec_extras[:required_ruby_version] = ">= 1.9.3"
   self.post_install_message = %Q{**************************************************
 *                                                *
 *  Thank you for installing #{self.name}-#{self.version}!     *


### PR DESCRIPTION
As explained in issue #10, gem-exefy can't be installed in Ruby 1.8.7,
because of that and to avoid loosing our hair by reports of people using
old version of Ruby, we avoid them installing it in the first place.

I know, thank me later.
